### PR TITLE
feat: deployable field hospitals

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "[sqf]": {
+
+
+        "editor.quickSuggestions": true,
+        "editor.tabSize": 4,
+        "editor.insertSpaces": true,
+        "editor.detectIndentation": false,
+        "editor.trimAutoWhitespace": true,
+        "editor.autoClosingBrackets": "always"
+    }
+}

--- a/KC_Liberation_Master_Framework/init.sqf
+++ b/KC_Liberation_Master_Framework/init.sqf
@@ -23,9 +23,11 @@ if (KPPLM_CBA && KP_liberation_playermenu) then {
 };
 
 [] call compileFinal preprocessFileLineNumbers "scripts\shared\init_shared.sqf";
+[] call compileFinal preprocessFileLineNumbers "karmakut\init_shared.sqf";
 
 if (isServer) then {
     [] call compileFinal preprocessFileLineNumbers "scripts\server\init_server.sqf";
+    [] call compileFinal preprocessFileLineNumbers "karmakut\init_server.sqf";
 };
 
 if (!isDedicated && !hasInterface && isMultiplayer) then {
@@ -46,6 +48,7 @@ if (!isDedicated && hasInterface) then {
     waitUntil {alive player};
     if (debug_source != name player) then {debug_source = name player};
     [] call compileFinal preprocessFileLineNumbers "scripts\client\init_client.sqf";
+    [] call compileFinal preprocessFileLineNumbers "karmakut\init_client.sqf";
 } else {
     setViewDistance 1600;
 };

--- a/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/client/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/client/init.sqf
@@ -1,4 +1,6 @@
 karma_deployableFieldHospitals_client_currentDeployedFieldHospital = objNull;
+karma_deployableFieldHospitals_client_isPerformingAction = false;
+karma_deployableFieldHospitals_client_actionAnimation = "Acts_TreatingWounded05";
 
 // Give the player an action to deploy a medical tent.
 player addAction [
@@ -10,15 +12,25 @@ player addAction [
     true,
     "",
     "
+        !karma_deployableFieldHospitals_client_isPerformingAction &&
+        alive player &&
         vehicle player == player &&
-        player getVariable ['ace_medical_medicclass', 0] == 2 &&
-        isNull karma_deployableFieldHospitals_client_currentDeployedFieldHospital;
+        isNull karma_deployableFieldHospitals_client_currentDeployedFieldHospital &&
+        (getPosATL player select 2) < 0.1 &&
+        player getVariable ['ace_medical_medicclass', 0] == 2;
     "
 ];
 
 // Handle field hospital deployment:
 karma_deployableFieldHospitals_client_deployFieldHospital = {
-    [player] remoteExecCall ["karma_deployableFieldHospitals_server_deployFieldHospital", 2];
+    [] spawn {
+        karma_deployableFieldHospitals_client_isPerformingAction = true;
+        player playMoveNow karma_deployableFieldHospitals_client_actionAnimation;
+        sleep 15;
+        [player] remoteExecCall ["karma_deployableFieldHospitals_server_deployFieldHospital", 2];
+        player playActionNow "Stand";
+        karma_deployableFieldHospitals_client_isPerformingAction = false;
+    };
 };
 
 karma_deployableFieldHospitals_client_handleFieldHospitalDeploymentResponse = {
@@ -43,6 +55,8 @@ karma_deployableFieldHospitals_client_handleFieldHospitalDeploymentResponse = {
             true,
             "",
             "
+                !karma_deployableFieldHospitals_client_isPerformingAction &&
+                alive player &&
                 vehicle player == player &&
                 player getVariable ['ace_medical_medicclass', 0] == 2 &&
                 getPlayerUID player == (_target getVariable ['karma_ownerUID', '']);
@@ -53,7 +67,14 @@ karma_deployableFieldHospitals_client_handleFieldHospitalDeploymentResponse = {
 
 // Handle field hospital repacking:
 karma_deployableFieldHospitals_client_repackFieldHospital = {
-    [player] remoteExecCall ["karma_deployableFieldHospitals_server_repackFieldHospital", 2];
+    [] spawn {
+        karma_deployableFieldHospitals_client_isPerformingAction = true;
+        player playMoveNow karma_deployableFieldHospitals_client_actionAnimation;
+        sleep 15;
+        [player] remoteExecCall ["karma_deployableFieldHospitals_server_repackFieldHospital", 2];
+        player playActionNow "Stand";
+        karma_deployableFieldHospitals_client_isPerformingAction = false;
+    };
 };
 
 karma_deployableFieldHospitals_client_handleFieldHospitalRepackResponse = {

--- a/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/client/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/client/init.sqf
@@ -1,0 +1,69 @@
+karma_deployableFieldHospitals_client_currentDeployedFieldHospital = objNull;
+
+// Give the player an action to deploy a medical tent.
+player addAction [
+    ["<t color='#FFFF00'>", localize "STR_KARMA_DEPLOY_FIELD_HOSPITAL", "</t><img size='2' image='res\ui_build.paa'/>"] joinString "",
+    { [] call karma_deployableFieldHospitals_client_deployFieldHospital; },
+    nil,
+    -750,
+    false,
+    true,
+    "",
+    "
+        vehicle player == player &&
+        player getVariable ['ace_medical_medicclass', 0] == 2 &&
+        isNull karma_deployableFieldHospitals_client_currentDeployedFieldHospital;
+    "
+];
+
+// Handle field hospital deployment:
+karma_deployableFieldHospitals_client_deployFieldHospital = {
+    [player] remoteExecCall ["karma_deployableFieldHospitals_server_deployFieldHospital", 2];
+};
+
+karma_deployableFieldHospitals_client_handleFieldHospitalDeploymentResponse = {
+    params [
+        ["_statusCode", -1],
+        ["_ownerUID", ""],
+        ["_fieldHospital", objNull]
+    ];
+
+    if (getPlayerUID player == _ownerUID) then {
+        karma_deployableFieldHospitals_client_currentDeployedFieldHospital = _fieldHospital;
+        hint (_statusCode call karma_deployableFieldHospitals_shared_getMessageForStatusCode);
+    };
+
+    if (!isNull _fieldHospital) then {
+        _fieldHospital addAction [
+            ["<t color='#FFFF00'>", localize "STR_KARMA_REPACK_FIELD_HOSPITAL", "</t>"] joinString "",
+            { [] call karma_deployableFieldHospitals_client_repackFieldHospital; },
+            nil,
+            -750,
+            false,
+            true,
+            "",
+            "
+                vehicle player == player &&
+                player getVariable ['ace_medical_medicclass', 0] == 2 &&
+                getPlayerUID player == (_target getVariable ['karma_ownerUID', '']);
+            "
+        ];
+    };
+};
+
+// Handle field hospital repacking:
+karma_deployableFieldHospitals_client_repackFieldHospital = {
+    [player] remoteExecCall ["karma_deployableFieldHospitals_server_repackFieldHospital", 2];
+};
+
+karma_deployableFieldHospitals_client_handleFieldHospitalRepackResponse = {
+    params [
+        ["_statusCode", -1],
+        ["_ownerUID", objNull]
+    ];
+
+    if (getPlayerUID player == _ownerUID) then {
+        karma_deployableFieldHospitals_client_currentDeployedFieldHospital = objNull;
+        hint (_statusCode call karma_deployableFieldHospitals_shared_getMessageForStatusCode);
+    };
+};

--- a/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/readme.md
+++ b/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/readme.md
@@ -1,0 +1,13 @@
+# Deployable Field Hospitals
+
+
+## Description
+Provides units with the "doctor" medical role to deploy field hospitals anywhere via the action menu.
+
+Deployed field hospitals can then be repacked and deployed again.
+
+Only one field hospital is allowed to be deployed at a time per doctor.
+
+
+## Technical Details
+A doctor is classified as a unit with the `ace_medical_medicclass` unit variable set to a value of `2`.

--- a/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/server/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/server/init.sqf
@@ -1,0 +1,61 @@
+karma_deployableFieldHospitals_server_fieldHospitalsByPlayerUID = createHashMap;
+
+karma_deployableFieldHospitals_server_deployFieldHospital = {
+    params [
+        ["_player", objNull]
+    ];
+
+    if (isNull _player) exitWith {};
+
+    private _playerUID = getPlayerUID _player;
+    if (!isNull (karma_deployableFieldHospitals_server_fieldHospitalsByPlayerUID getOrDefault [_playerUID, objNull])) exitWith {
+        [
+            karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalAlreadyDeployed,
+            _playerUID
+        ] remoteExecCall ["karma_deployableFieldHospitals_client_handleFieldHospitalDeploymentResponse"];
+    };
+
+    private _distanceFromPlayerToTerrain = getPosATL _player select 2;
+    if (_distanceFromPlayerToTerrain > 0.1) exitWith {
+        [
+            karma_deployableFieldHospitals_shared_statusCodes_playerNotOnTerrain,
+            _playerUID
+        ] remoteExecCall ["karma_deployableFieldHospitals_client_handleFieldHospitalDeploymentResponse"];
+    };
+
+    private _playerPosition = position player;
+    private _playerDirection = direction _player;
+    private _fieldHospitalSize = sizeOf karma_deployableFieldHospitals_shared_fieldHospitalClassname;
+    private _fieldHospital = karma_deployableFieldHospitals_shared_fieldHospitalClassname createVehicle _playerPosition;
+    _fieldHospital setDir _playerDirection;
+    _fieldHospital setPos _playerPosition;
+    [_fieldHospital] call KPLIB_fnc_addObjectInit;
+    _fieldHospital setVariable ["karma_ownerUID", _playerUID, true];
+    karma_deployableFieldHospitals_server_fieldHospitalsByPlayerUID set [_playerUID, _fieldHospital];
+
+    [
+        karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalDeployed,
+        _playerUID,
+        _fieldHospital
+    ] remoteExecCall ["karma_deployableFieldHospitals_client_handleFieldHospitalDeploymentResponse"];
+};
+
+karma_deployableFieldHospitals_server_repackFieldHospital = {
+    params [
+        ["_player", objNull]
+    ];
+
+    if (isNull _player) exitWith {};
+
+    private _playerUID = getPlayerUID _player;
+    private _fieldHospital = karma_deployableFieldHospitals_server_fieldHospitalsByPlayerUID getOrDefault [_playerUID, objNull];
+    karma_deployableFieldHospitals_server_fieldHospitalsByPlayerUID deleteAt _playerUID;
+    if (!isNull _fieldHospital) then {
+        deleteVehicle _fieldHospital;
+    };
+
+    [
+        karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalRepacked,
+        _playerUID
+    ] remoteExecCall ["karma_deployableFieldHospitals_client_handleFieldHospitalRepackResponse"];
+};

--- a/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/shared/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/shared/init.sqf
@@ -1,0 +1,32 @@
+// Field hospital metadata:
+karma_deployableFieldHospitals_shared_fieldHospitalClassname = "Land_MedicalTent_01_NATO_generic_open_F";
+
+// Statuses and messaging:
+karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalDeployed = 0;
+karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalAlreadyDeployed = 1;
+karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalRepacked = 2;
+karma_deployableFieldHospitals_shared_statusCodes_playerNotOnTerrain = 3;
+
+karma_deployableFieldHospitals_shared_messagesByStatusCode = createHashMapFromArray [
+    [
+        karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalDeployed,
+        localize "STR_KARMA_FIELD_HOSPITAL_DEPLOYED"
+    ],
+    [
+        karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalAlreadyDeployed,
+        localize "STR_KARMA_FIELD_HOSPITAL_ALREADY_DEPLOYED"
+    ],
+    [
+        karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalRepacked,
+        localize "STR_KARMA_FIELD_HOSPITAL_REPACKED"
+    ],
+    [
+        karma_deployableFieldHospitals_shared_statusCodes_playerNotOnTerrain,
+        localize "STR_KARMA_FIELD_HOSPITAL_MUST_BE_DEPLOYED_ON_TERRAIN"
+    ]
+];
+
+karma_deployableFieldHospitals_shared_getMessageForStatusCode = {
+    params ["_status_code"];
+    karma_deployableFieldHospitals_shared_messagesByStatusCode getOrDefault [_status_code, "UNKNOWN STATUS"];
+};

--- a/KC_Liberation_Master_Framework/karmakut/init_client.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/init_client.sqf
@@ -1,0 +1,1 @@
+[] call compileFinal preProcessFileLineNumbers "karmakut\deployable_field_hospitals\client\init.sqf";

--- a/KC_Liberation_Master_Framework/karmakut/init_server.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/init_server.sqf
@@ -1,0 +1,1 @@
+[] call compileFinal preProcessFileLineNumbers "karmakut\deployable_field_hospitals\server\init.sqf";

--- a/KC_Liberation_Master_Framework/karmakut/init_shared.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/init_shared.sqf
@@ -1,0 +1,1 @@
+[] call compileFinal preProcessFileLineNumbers "karmakut\deployable_field_hospitals\shared\init.sqf";

--- a/KC_Liberation_Master_Framework/kp_liberation_config.sqf
+++ b/KC_Liberation_Master_Framework/kp_liberation_config.sqf
@@ -58,6 +58,7 @@ KP_liberation_medical_vehicles = [
 KP_liberation_medical_facilities = [
     "Land_Medevac_house_V1_F",
     "Land_Medevac_HQ_V1_F",
+    "Land_MedicalTent_01_NATO_generic_open_F",
     "LAND_uns_army_med",
     "LAND_uns_tent3mash",
     "uns_mash_main",

--- a/KC_Liberation_Master_Framework/stringtable.xml
+++ b/KC_Liberation_Master_Framework/stringtable.xml
@@ -7318,4 +7318,43 @@
             <Czech>KP Player Menu v1.0.2\nby Wyqer</Czech>
         </Key>
     </Package>
+
+    <Package name="Karma">
+        <Key ID="STR_KARMA_DEPLOY_FIELD_HOSPITAL">
+            <English>Deploy Field Hospital</English>
+            <German>Bereitstellen des Feldkrankenhauses</German>
+            <Spanish>Implementar Hospital de campo</Spanish>
+            <Czech>Nasadit polní nemocnici</Czech>
+        </Key>
+        <Key ID="STR_KARMA_REPACK_FIELD_HOSPITAL">
+            <English>Repack Field Hospital</English>
+            <German>Feldkrankenhaus neu verpacken</German>
+            <Spanish>Reembalaje del hospital de campaña</Spanish>
+            <Czech>Přebalte polní nemocnici</Czech>
+        </Key>
+        <Key ID="STR_KARMA_FIELD_HOSPITAL_DEPLOYED">
+            <English>Field Hospital Deployed</English>
+            <German>Feldkrankenhaus im Einsatz</German>
+            <Spanish>Hospital de campaña desplegado</Spanish>
+            <Czech>Polní nemocnice nasazena</Czech>
+        </Key>
+        <Key ID="STR_KARMA_FIELD_HOSPITAL_ALREADY_DEPLOYED">
+            <English>Please repack your current field hospital before deploying a new one.</English>
+            <German>Bitte packen Sie Ihr aktuelles Feldkrankenhaus neu, bevor Sie ein neues einsetzen.</German>
+            <Spanish>Vuelva a embalar su hospital de campaña actual antes de instalar uno nuevo.</Spanish>
+            <Czech>Před nasazením nové polní nemocnice prosím znovu zabalte.</Czech>
+        </Key>
+        <Key ID="STR_KARMA_FIELD_HOSPITAL_REPACKED">
+            <English>Field Hospital Repacked</English>
+            <German>Feldkrankenhaus neu verpackt</German>
+            <Spanish>Hospital de campaña reembalado</Spanish>
+            <Czech>Polní nemocnice přebalena</Czech>
+        </Key>
+        <Key ID="STR_KARMA_FIELD_HOSPITAL_MUST_BE_DEPLOYED_ON_TERRAIN">
+            <English>Field hospitals can only be deployed on terrain.</English>
+            <German>Feldkrankenhäuser können nur im Gelände eingesetzt werden.</German>
+            <Spanish>Los hospitales de campaña solo se pueden desplegar en el terreno.</Spanish>
+            <Czech>Polní nemocnice lze nasadit pouze v terénu.</Czech>
+        </Key>
+    </Package>
 </Project>


### PR DESCRIPTION
## Description
Gives doctors the ability to deploy field hospitals anywhere. Only one field hospital can be deployed at a time per doctor, and can be repacked at any time to be deployed again.
Players that choose a role with the "doctor" ACE medic class will be given an action in their scroll menu to deploy a field hospital. Once a field hospital is deployed, the doctor can then scroll on it to repack it.

**Preview:**
https://gfycat.com/advancedacidicaruanas