### PR TITLE
fix: deployable field hospitals not positioned correctly for non-host players

### DIFF
--- a/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/server/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/server/init.sqf
@@ -8,10 +8,12 @@ karma_deployableFieldHospitals_server_deployFieldHospital = {
     if (isNull _player) exitWith {};
 
     private _playerUID = getPlayerUID _player;
-    if (!isNull (karma_deployableFieldHospitals_server_fieldHospitalsByPlayerUID getOrDefault [_playerUID, objNull])) exitWith {
+    private _existingFieldHospital = karma_deployableFieldHospitals_server_fieldHospitalsByPlayerUID getOrDefault [_playerUID, objNull];
+    if (!isNull _existingFieldHospital) exitWith {
         [
             karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalAlreadyDeployed,
-            _playerUID
+            _playerUID,
+            _existingFieldHospital
         ] remoteExecCall ["karma_deployableFieldHospitals_client_handleFieldHospitalDeploymentResponse"];
     };
 
@@ -23,9 +25,8 @@ karma_deployableFieldHospitals_server_deployFieldHospital = {
         ] remoteExecCall ["karma_deployableFieldHospitals_client_handleFieldHospitalDeploymentResponse"];
     };
 
-    private _playerPosition = position player;
+    private _playerPosition = position _player;
     private _playerDirection = direction _player;
-    private _fieldHospitalSize = sizeOf karma_deployableFieldHospitals_shared_fieldHospitalClassname;
     private _fieldHospital = karma_deployableFieldHospitals_shared_fieldHospitalClassname createVehicle _playerPosition;
     _fieldHospital setDir _playerDirection;
     _fieldHospital setPos _playerPosition;

--- a/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/shared/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/deployable_field_hospitals/shared/init.sqf
@@ -1,5 +1,5 @@
 // Field hospital metadata:
-karma_deployableFieldHospitals_shared_fieldHospitalClassname = "Land_MedicalTent_01_NATO_generic_open_F";
+karma_deployableFieldHospitals_shared_fieldHospitalClassname = "Land_MedicalTent_01_white_generic_outer_F"; // make sure to keep this in-sync with the associated entry in `KP_liberation_medical_facilities`.
 
 // Statuses and messaging:
 karma_deployableFieldHospitals_shared_statusCodes_fieldHospitalDeployed = 0;
@@ -27,6 +27,6 @@ karma_deployableFieldHospitals_shared_messagesByStatusCode = createHashMapFromAr
 ];
 
 karma_deployableFieldHospitals_shared_getMessageForStatusCode = {
-    params ["_status_code"];
-    karma_deployableFieldHospitals_shared_messagesByStatusCode getOrDefault [_status_code, "UNKNOWN STATUS"];
+    params ["_statusCode"];
+    karma_deployableFieldHospitals_shared_messagesByStatusCode getOrDefault [_statusCode, "UNKNOWN STATUS"];
 };

--- a/KC_Liberation_Master_Framework/kp_liberation_config.sqf
+++ b/KC_Liberation_Master_Framework/kp_liberation_config.sqf
@@ -58,7 +58,7 @@ KP_liberation_medical_vehicles = [
 KP_liberation_medical_facilities = [
     "Land_Medevac_house_V1_F",
     "Land_Medevac_HQ_V1_F",
-    "Land_MedicalTent_01_NATO_generic_open_F",
+    "Land_MedicalTent_01_white_generic_outer_F", // make this entry match the Field Hospital classname specified by `karma_deployableFieldHospitals_shared_fieldHospitalClassname`
     "LAND_uns_army_med",
     "LAND_uns_tent3mash",
     "uns_mash_main",


### PR DESCRIPTION
## Description
Fixes an issue with field hospitals not being deployed to the deploying player's position due to a typo when referencing the `_player` on the serverside during field hospital deployment.

**Bonus:**
- Changed the field hospital model to a white tent `Land_MedicalTent_01_white_generic_outer_F`.
- Ensure JIP doctors get their previously placed field hospital state rehydrated upon trying to place another field hospital after having placed one already in a previous session.
- Added comments to improve dev-experience when updating the field hospital classname, to inform them to also update the Liberation config.