### PR TITLE
feat: player trash cleanup

### DIFF
--- a/KC_Liberation_Master_Framework/karmakut/init_client.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/init_client.sqf
@@ -1,1 +1,2 @@
 [] call compileFinal preProcessFileLineNumbers "karmakut\deployable_field_hospitals\client\init.sqf";
+[] call compileFinal preProcessFileLineNumbers "karmakut\trash_cleanup\client\init.sqf";

--- a/KC_Liberation_Master_Framework/karmakut/init_server.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/init_server.sqf
@@ -1,1 +1,2 @@
 [] call compileFinal preProcessFileLineNumbers "karmakut\deployable_field_hospitals\server\init.sqf";
+[] call compileFinal preProcessFileLineNumbers "karmakut\trash_cleanup\server\init.sqf";

--- a/KC_Liberation_Master_Framework/karmakut/init_shared.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/init_shared.sqf
@@ -1,1 +1,2 @@
 [] call compileFinal preProcessFileLineNumbers "karmakut\deployable_field_hospitals\shared\init.sqf";
+[] call compileFinal preProcessFileLineNumbers "karmakut\trash_cleanup\shared\init.sqf";

--- a/KC_Liberation_Master_Framework/karmakut/trash_cleanup/client/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/trash_cleanup/client/init.sqf
@@ -1,0 +1,13 @@
+// Add an event handler to the player to 
+player addEventHandler ["InventoryClosed", {
+    params [
+        ["_unit", objNull],
+        ["_targetContainer", objNull]
+    ];
+    if (
+        !isNull _targetContainer && 
+        typeOf _targetContainer in karma_trashCleanup_shared_trashContainerClassnames
+    ) then {
+        [_targetContainer] remoteExec ["karma_trashCleanup_server_registerTrashContainer", 2];
+    };
+}];

--- a/KC_Liberation_Master_Framework/karmakut/trash_cleanup/client/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/trash_cleanup/client/init.sqf
@@ -1,4 +1,4 @@
-// Add an event handler to the player to 
+// Add an event handler to the player to queue dropped items for processing.
 player addEventHandler ["InventoryClosed", {
     params [
         ["_unit", objNull],

--- a/KC_Liberation_Master_Framework/karmakut/trash_cleanup/readme.md
+++ b/KC_Liberation_Master_Framework/karmakut/trash_cleanup/readme.md
@@ -1,0 +1,9 @@
+# Trash Cleanup
+
+## Description
+Removes trash/dropped equipment on the ground from players to improve performance.
+
+## Technical Details
+When a player drops items on the ground, it will send a message to the server
+about the resulting item clutter. The server will then clear all clutter that's 
+older than a specific age, defined by `karma_trashCleanup_shared_trashRemovalThresholdInSeconds`.

--- a/KC_Liberation_Master_Framework/karmakut/trash_cleanup/server/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/trash_cleanup/server/init.sqf
@@ -1,0 +1,48 @@
+karma_trashCleanup_server_trashToProcessPerIteration = 25;
+karma_trashCleanup_server_trashContainersToProcess = []; // Element structure: [_trashContainer, _creationTimestamp]
+karma_trashCleanup_server_queuedTrashContainers = [];
+karma_trashCleanup_server_queuedTrashContainersLock = false; // Used for preventing writes from interfering between queueing and processing.
+
+karma_trashCleanup_server_registerTrashContainer = {
+    params [
+        ["_trashContainer", objNull]
+    ];
+    if (isNull _trashContainer) exitWith {};
+    waitUntil { !karma_trashCleanup_server_queuedTrashContainersLock };
+    karma_trashCleanup_server_queuedTrashContainersLock = true;
+    karma_trashCleanup_server_queuedTrashContainers pushBack [_trashContainer, time];
+    karma_trashCleanup_server_queuedTrashContainersLock = false;
+};
+
+[] spawn {
+    while { true } do {
+        private _time = time;
+        private _trashIteration = 0;
+        {
+            private _trashContainer = _x select 0;
+            private _creationTimestamp = _x select 1;
+            private _isTrashOlderThanAllowedAge = _time - _creationTimestamp >= karma_trashCleanup_shared_trashRemovalThresholdInSeconds;
+
+            if (!isNull _trashContainer) then {
+                if (_isTrashOlderThanAllowedAge) then {
+                    deleteVehicle _trashContainer;
+                } else {
+                    karma_trashCleanup_server_queuedTrashContainers pushBack _x; // Trash isn't old enough to be removed, requeue for processing.
+                };
+            };
+
+            _trashIteration = _trashIteration + 1;
+            if (_trashIteration % karma_trashCleanup_server_trashToProcessPerIteration == 0) then {
+                sleep 1; // Take a break to avoid bogging down the server from processing too much trash at once.
+            };
+        } forEach karma_trashCleanup_server_trashContainersToProcess;
+
+        karma_trashCleanup_server_trashContainersToProcess = karma_trashCleanup_server_queuedTrashContainers;
+        waitUntil { !karma_trashCleanup_server_queuedTrashContainersLock };
+        karma_trashCleanup_server_queuedTrashContainersLock = true;
+        karma_trashCleanup_server_queuedTrashContainers = [];
+        karma_trashCleanup_server_queuedTrashContainersLock = false;
+
+        sleep 1;
+    };
+}

--- a/KC_Liberation_Master_Framework/karmakut/trash_cleanup/shared/init.sqf
+++ b/KC_Liberation_Master_Framework/karmakut/trash_cleanup/shared/init.sqf
@@ -1,0 +1,2 @@
+karma_trashCleanup_shared_trashRemovalThresholdInSeconds = 60;
+karma_trashCleanup_shared_trashContainerClassnames = ["GroundWeaponHolder"];


### PR DESCRIPTION
## Description
Removes stale trash/equipment dropped by players to improve performance.

**Preview:** https://gfycat.com/politedevotedjavalina _(removal time is set to 10 seconds in this video for demonstration purposes)_

## Technical Details
When a player drops items on the ground, it will send a message to the server about the resulting item clutter. The server will then clear all clutter that's older than a specific age, defined by `karma_trashCleanup_shared_trashRemovalThresholdInSeconds`.